### PR TITLE
fix: unique UniFi route distances and re-add after delete (0.1.42)

### DIFF
--- a/chart/unifi-thread-route-updater/Chart.yaml
+++ b/chart/unifi-thread-route-updater/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: unifi-thread-route-updater
 description: A Helm chart for Thread Route Updater - automatically manages Thread network static routes on Ubiquiti routers
 type: application
-version: 0.1.41
-appVersion: "0.1.41"
+version: 0.1.42
+appVersion: "0.1.42"
 home: https://github.com/rafaelgaspar/unifi-thread-route-updater
 sources:
   - https://github.com/rafaelgaspar/unifi-thread-route-updater

--- a/types.go
+++ b/types.go
@@ -33,6 +33,7 @@ type Route struct {
 // DaemonState holds the current state of discovered routers and Thread mesh prefixes
 type DaemonState struct {
 	mu                   sync.Mutex
+	routeSyncMu          sync.Mutex // serialises UniFi route sync goroutines
 	ThreadBorderRouters  []ThreadBorderRouter
 	ThreadMeshPrefixes   map[string]time.Time // fd:: prefixes from TBR omr= TXT records → last seen time
 	UbiquityConfig       UbiquityConfig

--- a/ubiquity.go
+++ b/ubiquity.go
@@ -17,6 +17,9 @@ func updateUbiquityRoutes(state *DaemonState, routes []Route) {
 		return
 	}
 
+	state.routeSyncMu.Lock()
+	defer state.routeSyncMu.Unlock()
+
 	logInfo("UniFi: syncing static routes...")
 
 	if !state.UbiquityConfig.hasValidSession() {
@@ -85,18 +88,6 @@ func updateUbiquityRoutes(state *DaemonState, routes []Route) {
 		logInfo("UniFi: route changes +%d -%d", len(routesToAdd), len(routesToRemove))
 	}
 
-	state.mu.Lock()
-	var newRoutesToAdd []UbiquityStaticRoute
-	for _, route := range routesToAdd {
-		key := fmt.Sprintf("%s->%s", route.StaticRouteNetwork, route.StaticRouteNexthop)
-		if !state.AddedRoutes[key] {
-			newRoutesToAdd = append(newRoutesToAdd, route)
-			state.AddedRoutes[key] = true
-		}
-	}
-	state.mu.Unlock()
-	routesToAdd = newRoutesToAdd
-
 	if len(routesToAdd) > 0 {
 		time.Sleep(2 * time.Second)
 	}
@@ -116,14 +107,34 @@ func updateUbiquityRoutes(state *DaemonState, routes []Route) {
 			}
 		} else {
 			logInfo("UniFi: deleted route %s -> %s", route.StaticRouteNetwork, route.StaticRouteNexthop)
+			key := fmt.Sprintf("%s->%s", route.StaticRouteNetwork, route.StaticRouteNexthop)
+			state.mu.Lock()
+			delete(state.AddedRoutes, key)
+			state.mu.Unlock()
 		}
 	}
 
-	for _, route := range routesToAdd {
-		if err := addUbiquityStaticRoute(state.UbiquityConfig, route); err != nil {
+	for i := range routesToAdd {
+		route := routesToAdd[i]
+		for attempt := 0; attempt < 5; attempt++ {
+			err := addUbiquityStaticRoute(state.UbiquityConfig, route)
+			if err == nil {
+				logInfo("UniFi: added route %s -> %s (%s)", route.StaticRouteNetwork, route.StaticRouteNexthop, route.Name)
+				key := fmt.Sprintf("%s->%s", route.StaticRouteNetwork, route.StaticRouteNexthop)
+				state.mu.Lock()
+				state.AddedRoutes[key] = true
+				state.mu.Unlock()
+				break
+			}
+			if strings.Contains(err.Error(), "DestinationNetworkExisted") && attempt < 4 {
+				route.StaticRouteDistance++
+				routesToAdd[i].StaticRouteDistance = route.StaticRouteDistance
+				logWarn("UniFi: distance collision for %s, retrying with distance %d",
+					route.StaticRouteNetwork, route.StaticRouteDistance)
+				continue
+			}
 			logError("UniFi: add failed %s: %v", route.StaticRouteNetwork, err)
-		} else {
-			logInfo("UniFi: added route %s -> %s (%s)", route.StaticRouteNetwork, route.StaticRouteNexthop, route.Name)
+			break
 		}
 	}
 
@@ -279,18 +290,31 @@ func convertToUbiquityRoutes(routes []Route, gatewayDevice string) []UbiquitySta
 	return ubiquityRoutes
 }
 
-// assignRouteDistances sets StaticRouteDistance on routes that need to be added,
-// picking max(existing distances for that prefix) + 1 to avoid collisions.
+// assignRouteDistances sets StaticRouteDistance on routes that need to be added.
+// UniFi requires a unique distance (priority) per destination prefix; multiple
+// nexthops to the same prefix are allowed with different distances.
+//
+// The GET API often omits static-route_distance (zero value), so we also use the
+// number of existing routes per prefix as a floor when picking the next distance.
 func assignRouteDistances(toAdd []UbiquityStaticRoute, current []UbiquityStaticRoute) {
 	maxDistByPrefix := make(map[string]int)
+	countByPrefix := make(map[string]int)
 	for _, r := range current {
+		countByPrefix[r.StaticRouteNetwork]++
 		if r.StaticRouteDistance > maxDistByPrefix[r.StaticRouteNetwork] {
 			maxDistByPrefix[r.StaticRouteNetwork] = r.StaticRouteDistance
 		}
 	}
 	for i := range toAdd {
-		maxDistByPrefix[toAdd[i].StaticRouteNetwork]++
-		toAdd[i].StaticRouteDistance = maxDistByPrefix[toAdd[i].StaticRouteNetwork]
+		prefix := toAdd[i].StaticRouteNetwork
+		next := maxDistByPrefix[prefix]
+		if countByPrefix[prefix] > next {
+			next = countByPrefix[prefix]
+		}
+		next++
+		maxDistByPrefix[prefix] = next
+		countByPrefix[prefix]++
+		toAdd[i].StaticRouteDistance = next
 	}
 }
 

--- a/ubiquity.go
+++ b/ubiquity.go
@@ -82,7 +82,8 @@ func updateUbiquityRoutes(state *DaemonState, routes []Route) {
 	routesToAdd, routesToRemove := compareRoutesWithGracePeriod(currentRoutes, desiredRoutes, state.RouteLastSeen, state.UbiquityConfig.RouteGracePeriod)
 	state.mu.Unlock()
 
-	assignRouteDistances(routesToAdd, currentRoutes)
+	distances := newDistanceAllocator(currentRoutes)
+	distances.assign(routesToAdd)
 
 	if len(routesToAdd) > 0 || len(routesToRemove) > 0 {
 		logInfo("UniFi: route changes +%d -%d", len(routesToAdd), len(routesToRemove))
@@ -127,10 +128,18 @@ func updateUbiquityRoutes(state *DaemonState, routes []Route) {
 				break
 			}
 			if strings.Contains(err.Error(), "DestinationNetworkExisted") && attempt < 4 {
-				route.StaticRouteDistance++
-				routesToAdd[i].StaticRouteDistance = route.StaticRouteDistance
+				prefix := route.StaticRouteNetwork
+				distances.markUsed(prefix, route.StaticRouteDistance)
+				next, ok := distances.nextFree(prefix)
+				for !ok {
+					distances.count[prefix]++
+					next, ok = distances.nextFree(prefix)
+				}
+				route.StaticRouteDistance = next
+				routesToAdd[i].StaticRouteDistance = next
+				distances.markUsed(prefix, next)
 				logWarn("UniFi: distance collision for %s, retrying with distance %d",
-					route.StaticRouteNetwork, route.StaticRouteDistance)
+					prefix, next)
 				continue
 			}
 			logError("UniFi: add failed %s: %v", route.StaticRouteNetwork, err)
@@ -290,31 +299,70 @@ func convertToUbiquityRoutes(routes []Route, gatewayDevice string) []UbiquitySta
 	return ubiquityRoutes
 }
 
-// assignRouteDistances sets StaticRouteDistance on routes that need to be added.
-// UniFi requires a unique distance (priority) per destination prefix; multiple
-// nexthops to the same prefix are allowed with different distances.
-//
-// The GET API often omits static-route_distance (zero value), so we also use the
-// number of existing routes per prefix as a floor when picking the next distance.
-func assignRouteDistances(toAdd []UbiquityStaticRoute, current []UbiquityStaticRoute) {
-	maxDistByPrefix := make(map[string]int)
-	countByPrefix := make(map[string]int)
+// distanceAllocator picks the lowest unused distance in 1..N per destination prefix,
+// where N is the total route count for that prefix (existing + pending adds).
+type distanceAllocator struct {
+	used  map[string]map[int]bool
+	count map[string]int
+}
+
+func newDistanceAllocator(current []UbiquityStaticRoute) *distanceAllocator {
+	a := &distanceAllocator{
+		used:  make(map[string]map[int]bool),
+		count: make(map[string]int),
+	}
+	zeroDist := make(map[string]int)
 	for _, r := range current {
-		countByPrefix[r.StaticRouteNetwork]++
-		if r.StaticRouteDistance > maxDistByPrefix[r.StaticRouteNetwork] {
-			maxDistByPrefix[r.StaticRouteNetwork] = r.StaticRouteDistance
+		prefix := r.StaticRouteNetwork
+		a.count[prefix]++
+		if a.used[prefix] == nil {
+			a.used[prefix] = make(map[int]bool)
+		}
+		if r.StaticRouteDistance > 0 {
+			a.used[prefix][r.StaticRouteDistance] = true
+		} else {
+			zeroDist[prefix]++
 		}
 	}
+	// GET often omits static-route_distance; reserve the lowest slots for those routes.
+	for prefix, zeros := range zeroDist {
+		for z := 0; z < zeros; z++ {
+			if d, ok := a.nextFree(prefix); ok {
+				a.markUsed(prefix, d)
+			}
+		}
+	}
+	return a
+}
+
+func (a *distanceAllocator) markUsed(prefix string, distance int) {
+	if a.used[prefix] == nil {
+		a.used[prefix] = make(map[int]bool)
+	}
+	a.used[prefix][distance] = true
+}
+
+// nextFree returns the lowest unused distance in 1..count[prefix].
+func (a *distanceAllocator) nextFree(prefix string) (int, bool) {
+	for d := 1; d <= a.count[prefix]; d++ {
+		if used := a.used[prefix]; used == nil || !used[d] {
+			return d, true
+		}
+	}
+	return 0, false
+}
+
+func (a *distanceAllocator) assign(toAdd []UbiquityStaticRoute) {
 	for i := range toAdd {
 		prefix := toAdd[i].StaticRouteNetwork
-		next := maxDistByPrefix[prefix]
-		if countByPrefix[prefix] > next {
-			next = countByPrefix[prefix]
+		a.count[prefix]++
+		d, ok := a.nextFree(prefix)
+		if !ok {
+			// Should not happen: N routes should always have a free slot in 1..N.
+			d = a.count[prefix]
 		}
-		next++
-		maxDistByPrefix[prefix] = next
-		countByPrefix[prefix]++
-		toAdd[i].StaticRouteDistance = next
+		a.markUsed(prefix, d)
+		toAdd[i].StaticRouteDistance = d
 	}
 }
 

--- a/ubiquity_test.go
+++ b/ubiquity_test.go
@@ -199,6 +199,52 @@ func TestCompareRoutesWithGracePeriod(t *testing.T) {
 	}
 }
 
+// TestAssignRouteDistances verifies unique distance assignment per destination prefix.
+func TestAssignRouteDistances(t *testing.T) {
+	prefix := "fd36:1fa8:d5a::/64"
+
+	t.Run("empty current, batch of three", func(t *testing.T) {
+		toAdd := []UbiquityStaticRoute{
+			{StaticRouteNetwork: prefix, StaticRouteNexthop: "2001::1"},
+			{StaticRouteNetwork: prefix, StaticRouteNexthop: "2001::2"},
+			{StaticRouteNetwork: prefix, StaticRouteNexthop: "2001::3"},
+		}
+		assignRouteDistances(toAdd, nil)
+		if toAdd[0].StaticRouteDistance != 1 || toAdd[1].StaticRouteDistance != 2 || toAdd[2].StaticRouteDistance != 3 {
+			t.Errorf("expected distances 1,2,3 got %d,%d,%d",
+				toAdd[0].StaticRouteDistance, toAdd[1].StaticRouteDistance, toAdd[2].StaticRouteDistance)
+		}
+	})
+
+	t.Run("current routes with missing distance field", func(t *testing.T) {
+		current := []UbiquityStaticRoute{
+			{StaticRouteNetwork: prefix, StaticRouteNexthop: "2001::1", StaticRouteDistance: 0},
+			{StaticRouteNetwork: prefix, StaticRouteNexthop: "2001::2", StaticRouteDistance: 0},
+		}
+		toAdd := []UbiquityStaticRoute{
+			{StaticRouteNetwork: prefix, StaticRouteNexthop: "2001::3"},
+		}
+		assignRouteDistances(toAdd, current)
+		if toAdd[0].StaticRouteDistance != 3 {
+			t.Errorf("expected distance 3 when two existing routes omit distance, got %d", toAdd[0].StaticRouteDistance)
+		}
+	})
+
+	t.Run("current routes with explicit distances", func(t *testing.T) {
+		current := []UbiquityStaticRoute{
+			{StaticRouteNetwork: prefix, StaticRouteNexthop: "2001::1", StaticRouteDistance: 1},
+			{StaticRouteNetwork: prefix, StaticRouteNexthop: "2001::2", StaticRouteDistance: 4},
+		}
+		toAdd := []UbiquityStaticRoute{
+			{StaticRouteNetwork: prefix, StaticRouteNexthop: "2001::3"},
+		}
+		assignRouteDistances(toAdd, current)
+		if toAdd[0].StaticRouteDistance != 5 {
+			t.Errorf("expected distance max+1=5, got %d", toAdd[0].StaticRouteDistance)
+		}
+	})
+}
+
 // TestCreateHTTPClient tests the HTTP client creation with different configurations
 func TestCreateHTTPClient(t *testing.T) {
 	tests := []struct {

--- a/ubiquity_test.go
+++ b/ubiquity_test.go
@@ -199,8 +199,8 @@ func TestCompareRoutesWithGracePeriod(t *testing.T) {
 	}
 }
 
-// TestAssignRouteDistances verifies unique distance assignment per destination prefix.
-func TestAssignRouteDistances(t *testing.T) {
+// TestDistanceAllocator verifies compact distance assignment in 1..N per prefix.
+func TestDistanceAllocator(t *testing.T) {
 	prefix := "fd36:1fa8:d5a::/64"
 
 	t.Run("empty current, batch of three", func(t *testing.T) {
@@ -209,7 +209,7 @@ func TestAssignRouteDistances(t *testing.T) {
 			{StaticRouteNetwork: prefix, StaticRouteNexthop: "2001::2"},
 			{StaticRouteNetwork: prefix, StaticRouteNexthop: "2001::3"},
 		}
-		assignRouteDistances(toAdd, nil)
+		newDistanceAllocator(nil).assign(toAdd)
 		if toAdd[0].StaticRouteDistance != 1 || toAdd[1].StaticRouteDistance != 2 || toAdd[2].StaticRouteDistance != 3 {
 			t.Errorf("expected distances 1,2,3 got %d,%d,%d",
 				toAdd[0].StaticRouteDistance, toAdd[1].StaticRouteDistance, toAdd[2].StaticRouteDistance)
@@ -224,13 +224,13 @@ func TestAssignRouteDistances(t *testing.T) {
 		toAdd := []UbiquityStaticRoute{
 			{StaticRouteNetwork: prefix, StaticRouteNexthop: "2001::3"},
 		}
-		assignRouteDistances(toAdd, current)
+		newDistanceAllocator(current).assign(toAdd)
 		if toAdd[0].StaticRouteDistance != 3 {
 			t.Errorf("expected distance 3 when two existing routes omit distance, got %d", toAdd[0].StaticRouteDistance)
 		}
 	})
 
-	t.Run("current routes with explicit distances", func(t *testing.T) {
+	t.Run("fills gap instead of max+1", func(t *testing.T) {
 		current := []UbiquityStaticRoute{
 			{StaticRouteNetwork: prefix, StaticRouteNexthop: "2001::1", StaticRouteDistance: 1},
 			{StaticRouteNetwork: prefix, StaticRouteNexthop: "2001::2", StaticRouteDistance: 4},
@@ -238,9 +238,9 @@ func TestAssignRouteDistances(t *testing.T) {
 		toAdd := []UbiquityStaticRoute{
 			{StaticRouteNetwork: prefix, StaticRouteNexthop: "2001::3"},
 		}
-		assignRouteDistances(toAdd, current)
-		if toAdd[0].StaticRouteDistance != 5 {
-			t.Errorf("expected distance max+1=5, got %d", toAdd[0].StaticRouteDistance)
+		newDistanceAllocator(current).assign(toAdd)
+		if toAdd[0].StaticRouteDistance != 2 {
+			t.Errorf("expected distance 2 (gap fill), got %d", toAdd[0].StaticRouteDistance)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Fixes UniFi static route distance collisions (`api.err.DestinationNetworkExisted`) and the stuck re-add behaviour for deleted routes (e.g. Living Room Apple TV).

## Changes

### Route distance assignment
- Pick the **lowest free distance in 1..N** per prefix (N = route count), not `max+1`
- Fills gaps (e.g. existing distances 1 and 4 → next route gets 2, not 5)
- When GET omits `static-route_distance`, reserve the lowest slots for those routes
- On `DestinationNetworkExisted`, mark the colliding slot and retry with the next free value (expanding N only if needed)

### AddedRoutes lifecycle
- Only mark routes as added after a successful POST
- Clear `AddedRoutes` on delete so removed routes can be re-added

### Concurrency
- Serialise overlapping `updateUbiquityRoutes` goroutines with `routeSyncMu`

### Release
- Bump chart `version` and `appVersion` to **0.1.42**

## Testing

```
go test ./... -count=1
```