### PR TITLE
feat(chart): embed VLAN16 Multus NAD in app chart (0.1.43)

### DIFF
--- a/chart/unifi-thread-route-updater/Chart.yaml
+++ b/chart/unifi-thread-route-updater/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: unifi-thread-route-updater
 description: A Helm chart for Thread Route Updater - automatically manages Thread network static routes on Ubiquiti routers
 type: application
-version: 0.1.42
-appVersion: "0.1.42"
+version: 0.1.43
+appVersion: "0.1.43"
 home: https://github.com/rafaelgaspar/unifi-thread-route-updater
 sources:
   - https://github.com/rafaelgaspar/unifi-thread-route-updater

--- a/chart/unifi-thread-route-updater/templates/_helpers.tpl
+++ b/chart/unifi-thread-route-updater/templates/_helpers.tpl
@@ -61,3 +61,17 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{/*
+VLAN16 Multus NAD name (defaults to <fullname>-vlan16).
+*/}}
+{{- define "unifi-thread-route-updater.vlan16.name" -}}
+{{- default (printf "%s-vlan16" (include "unifi-thread-route-updater.fullname" .)) .Values.vlan16.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Multus networks annotation value: <nad-name>@<interface>.
+*/}}
+{{- define "unifi-thread-route-updater.vlan16.networksAnnotation" -}}
+{{- printf "%s@%s" (include "unifi-thread-route-updater.vlan16.name" .) .Values.vlan16.interface }}
+{{- end }}
+

--- a/chart/unifi-thread-route-updater/templates/deployment.yaml
+++ b/chart/unifi-thread-route-updater/templates/deployment.yaml
@@ -13,10 +13,13 @@ spec:
       {{- include "unifi-thread-route-updater.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        {{- if .Values.vlan16.enabled }}
+        k8s.v1.cni.cncf.io/networks: {{ include "unifi-thread-route-updater.vlan16.networksAnnotation" . | quote }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "unifi-thread-route-updater.selectorLabels" . | nindent 8 }}
     spec:

--- a/chart/unifi-thread-route-updater/templates/networkattachmentdefinition.yaml
+++ b/chart/unifi-thread-route-updater/templates/networkattachmentdefinition.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.vlan16.enabled }}
+{{- if not .Values.vlan16.mac }}
+{{- fail "vlan16.mac is required when vlan16.enabled is true" }}
+{{- end }}
+{{- $ipam := dict "type" "dhcp" }}
+{{- if not .Values.vlan16.dhcp }}
+{{- if not .Values.vlan16.address }}
+{{- fail "vlan16.address is required when vlan16.dhcp is false" }}
+{{- end }}
+{{- $addr := dict "address" .Values.vlan16.address }}
+{{- if .Values.vlan16.gateway }}
+{{- $_ := set $addr "gateway" .Values.vlan16.gateway }}
+{{- end }}
+{{- $ipam = dict "type" "static" "addresses" (list $addr) "routes" (.Values.vlan16.routes | default list) }}
+{{- end }}
+{{- $macvlan := dict "type" "macvlan" "master" .Values.vlan16.master "mode" "bridge" "mac" .Values.vlan16.mac "ipam" $ipam }}
+{{- $plugins := list $macvlan }}
+{{- if and .Values.vlan16.tuning .Values.vlan16.tuning.sysctls (not (empty .Values.vlan16.tuning.sysctls)) }}
+{{- $plugins = append $plugins (dict "type" "tuning" "sysctl" .Values.vlan16.tuning.sysctls) }}
+{{- end }}
+{{- $plugins = append $plugins (dict "type" "sbr") }}
+{{- $config := dict "cniVersion" "0.4.0" "plugins" $plugins }}
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: {{ include "unifi-thread-route-updater.vlan16.name" . }}
+  labels:
+    {{- include "unifi-thread-route-updater.labels" . | nindent 4 }}
+spec:
+  config: |
+{{ $config | toPrettyJson | indent 4 }}
+{{- end }}

--- a/chart/unifi-thread-route-updater/values-example.yaml
+++ b/chart/unifi-thread-route-updater/values-example.yaml
@@ -41,6 +41,12 @@ resources:
     cpu: 50m
     memory: 64Mi
 
+# VLAN16 macvlan (Multus) for direct IoT network access.
+vlan16:
+  enabled: true
+  mac: "02:00:00:16:00:42"
+  dhcp: true
+
 # Enable monitoring (requires Prometheus operator)
 serviceMonitor:
   enabled: false

--- a/chart/unifi-thread-route-updater/values.yaml
+++ b/chart/unifi-thread-route-updater/values.yaml
@@ -23,6 +23,25 @@ serviceAccount:
 
 podAnnotations: {}
 
+# Optional VLAN16 macvlan attachment (Multus NAD + pod annotation).
+# Requires kube-system/cni-dhcp when dhcp is true, plus a matching UniFi reservation.
+vlan16:
+  enabled: false
+  # NAD name; defaults to <release-name>-vlan16.
+  name: ""
+  # Pod interface name for the secondary network.
+  interface: eth1
+  master: br16
+  # Pinned locally-administered MAC — required when enabled.
+  mac: ""
+  dhcp: true
+  # Static IPAM (when dhcp is false).
+  address: ""
+  gateway: 192.168.16.1
+  routes: []
+  tuning:
+    sysctls: {}
+
 podSecurityContext:
   fsGroup: 1001
 


### PR DESCRIPTION
## Summary
- Add optional `vlan16` values block (pinned MAC, dhcp/static IPAM, `br16` master).
- Render `NetworkAttachmentDefinition` and set `k8s.v1.cni.cncf.io/networks` on the Deployment when enabled.
- Bump `version` and `appVersion` together to **0.1.43**.

## Test plan
- [ ] `helm template` with `vlan16.enabled=true` renders NAD + annotation
- [ ] Tag `v0.1.43` after merge to publish OCI chart/image
- [ ] k3s-home PR bumps HelmRelease to `0.1.43` and drops separate vlan-attachment release


Made with [Cursor](https://cursor.com)