### PR TITLE
refactor(chart): rename vlan16 to networkAttachmentDefinition

### DIFF
--- a/chart/unifi-thread-route-updater/Chart.yaml
+++ b/chart/unifi-thread-route-updater/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: unifi-thread-route-updater
 description: A Helm chart for Thread Route Updater - automatically manages Thread network static routes on Ubiquiti routers
 type: application
-version: 0.1.43
-appVersion: "0.1.43"
+version: 0.1.44
+appVersion: "0.1.44"
 home: https://github.com/rafaelgaspar/unifi-thread-route-updater
 sources:
   - https://github.com/rafaelgaspar/unifi-thread-route-updater

--- a/chart/unifi-thread-route-updater/templates/_helpers.tpl
+++ b/chart/unifi-thread-route-updater/templates/_helpers.tpl
@@ -62,16 +62,16 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-VLAN16 Multus NAD name (defaults to <fullname>-vlan16).
+Multus NetworkAttachmentDefinition name (defaults to <fullname>-nad).
 */}}
-{{- define "unifi-thread-route-updater.vlan16.name" -}}
-{{- default (printf "%s-vlan16" (include "unifi-thread-route-updater.fullname" .)) .Values.vlan16.name | trunc 63 | trimSuffix "-" }}
+{{- define "unifi-thread-route-updater.networkAttachmentDefinition.name" -}}
+{{- default (printf "%s-nad" (include "unifi-thread-route-updater.fullname" .)) .Values.networkAttachmentDefinition.name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Multus networks annotation value: <nad-name>@<interface>.
 */}}
-{{- define "unifi-thread-route-updater.vlan16.networksAnnotation" -}}
-{{- printf "%s@%s" (include "unifi-thread-route-updater.vlan16.name" .) .Values.vlan16.interface }}
+{{- define "unifi-thread-route-updater.networkAttachmentDefinition.networksAnnotation" -}}
+{{- printf "%s@%s" (include "unifi-thread-route-updater.networkAttachmentDefinition.name" .) .Values.networkAttachmentDefinition.interface }}
 {{- end }}
 

--- a/chart/unifi-thread-route-updater/templates/deployment.yaml
+++ b/chart/unifi-thread-route-updater/templates/deployment.yaml
@@ -14,8 +14,8 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if .Values.vlan16.enabled }}
-        k8s.v1.cni.cncf.io/networks: {{ include "unifi-thread-route-updater.vlan16.networksAnnotation" . | quote }}
+        {{- if .Values.networkAttachmentDefinition.enabled }}
+        k8s.v1.cni.cncf.io/networks: {{ include "unifi-thread-route-updater.networkAttachmentDefinition.networksAnnotation" . | quote }}
         {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/chart/unifi-thread-route-updater/templates/networkattachmentdefinition.yaml
+++ b/chart/unifi-thread-route-updater/templates/networkattachmentdefinition.yaml
@@ -1,29 +1,32 @@
-{{- if .Values.vlan16.enabled }}
-{{- if not .Values.vlan16.mac }}
-{{- fail "vlan16.mac is required when vlan16.enabled is true" }}
+{{- if .Values.networkAttachmentDefinition.enabled }}
+{{- if not .Values.networkAttachmentDefinition.master }}
+{{- fail "networkAttachmentDefinition.master is required when networkAttachmentDefinition.enabled is true" }}
+{{- end }}
+{{- if not .Values.networkAttachmentDefinition.mac }}
+{{- fail "networkAttachmentDefinition.mac is required when networkAttachmentDefinition.enabled is true" }}
 {{- end }}
 {{- $ipam := dict "type" "dhcp" }}
-{{- if not .Values.vlan16.dhcp }}
-{{- if not .Values.vlan16.address }}
-{{- fail "vlan16.address is required when vlan16.dhcp is false" }}
+{{- if not .Values.networkAttachmentDefinition.dhcp }}
+{{- if not .Values.networkAttachmentDefinition.address }}
+{{- fail "networkAttachmentDefinition.address is required when networkAttachmentDefinition.dhcp is false" }}
 {{- end }}
-{{- $addr := dict "address" .Values.vlan16.address }}
-{{- if .Values.vlan16.gateway }}
-{{- $_ := set $addr "gateway" .Values.vlan16.gateway }}
+{{- $addr := dict "address" .Values.networkAttachmentDefinition.address }}
+{{- if .Values.networkAttachmentDefinition.gateway }}
+{{- $_ := set $addr "gateway" .Values.networkAttachmentDefinition.gateway }}
 {{- end }}
-{{- $ipam = dict "type" "static" "addresses" (list $addr) "routes" (.Values.vlan16.routes | default list) }}
+{{- $ipam = dict "type" "static" "addresses" (list $addr) "routes" (.Values.networkAttachmentDefinition.routes | default list) }}
 {{- end }}
-{{- $macvlan := dict "type" "macvlan" "master" .Values.vlan16.master "mode" "bridge" "mac" .Values.vlan16.mac "ipam" $ipam }}
+{{- $macvlan := dict "type" "macvlan" "master" .Values.networkAttachmentDefinition.master "mode" "bridge" "mac" .Values.networkAttachmentDefinition.mac "ipam" $ipam }}
 {{- $plugins := list $macvlan }}
-{{- if and .Values.vlan16.tuning .Values.vlan16.tuning.sysctls (not (empty .Values.vlan16.tuning.sysctls)) }}
-{{- $plugins = append $plugins (dict "type" "tuning" "sysctl" .Values.vlan16.tuning.sysctls) }}
+{{- if and .Values.networkAttachmentDefinition.tuning .Values.networkAttachmentDefinition.tuning.sysctls (not (empty .Values.networkAttachmentDefinition.tuning.sysctls)) }}
+{{- $plugins = append $plugins (dict "type" "tuning" "sysctl" .Values.networkAttachmentDefinition.tuning.sysctls) }}
 {{- end }}
 {{- $plugins = append $plugins (dict "type" "sbr") }}
 {{- $config := dict "cniVersion" "0.4.0" "plugins" $plugins }}
 apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:
-  name: {{ include "unifi-thread-route-updater.vlan16.name" . }}
+  name: {{ include "unifi-thread-route-updater.networkAttachmentDefinition.name" . }}
   labels:
     {{- include "unifi-thread-route-updater.labels" . | nindent 4 }}
 spec:

--- a/chart/unifi-thread-route-updater/values-example.yaml
+++ b/chart/unifi-thread-route-updater/values-example.yaml
@@ -41,11 +41,13 @@ resources:
     cpu: 50m
     memory: 64Mi
 
-# VLAN16 macvlan (Multus) for direct IoT network access.
-vlan16:
+# Optional Multus macvlan attachment (example — customize for your cluster).
+networkAttachmentDefinition:
   enabled: true
+  master: br16
   mac: "02:00:00:16:00:42"
   dhcp: true
+  gateway: 192.168.16.1
 
 # Enable monitoring (requires Prometheus operator)
 serviceMonitor:

--- a/chart/unifi-thread-route-updater/values.yaml
+++ b/chart/unifi-thread-route-updater/values.yaml
@@ -23,21 +23,22 @@ serviceAccount:
 
 podAnnotations: {}
 
-# Optional VLAN16 macvlan attachment (Multus NAD + pod annotation).
-# Requires kube-system/cni-dhcp when dhcp is true, plus a matching UniFi reservation.
-vlan16:
+# Optional Multus NetworkAttachmentDefinition (macvlan) + pod network annotation.
+networkAttachmentDefinition:
   enabled: false
-  # NAD name; defaults to <release-name>-vlan16.
+  # NAD name; defaults to <release-name>-nad.
   name: ""
   # Pod interface name for the secondary network.
   interface: eth1
-  master: br16
-  # Pinned locally-administered MAC — required when enabled.
+  # Host bridge for macvlan (e.g. br16).
+  master: ""
+  # Pinned MAC — required when enabled.
   mac: ""
+  # CNI dhcp IPAM (requires a cluster dhcp daemon when true).
   dhcp: true
   # Static IPAM (when dhcp is false).
   address: ""
-  gateway: 192.168.16.1
+  gateway: ""
   routes: []
   tuning:
     sysctls: {}


### PR DESCRIPTION
## Summary
- Rename the optional Multus NAD values block from `vlan16` to `networkAttachmentDefinition` so the chart is not opinionated about VLAN 16
- Require `master` and `mac` when enabled; default NAD name is `<fullname>-nad`
- Bump chart to `0.1.44`

## Test plan
- [x] `helm lint` with NAD enabled
- [x] `helm template` renders NAD + `k8s.v1.cni.cncf.io/networks` annotation
- [ ] Merge and tag `v0.1.44` for OCI publish
- [ ] Update k3s-home HelmRelease to use `networkAttachmentDefinition` + `0.1.44`


Made with [Cursor](https://cursor.com)