### PR TITLE
fix(chart): add configurable deployment strategy

### DIFF
--- a/chart/unifi-thread-route-updater/Chart.yaml
+++ b/chart/unifi-thread-route-updater/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: unifi-thread-route-updater
 description: A Helm chart for Thread Route Updater - automatically manages Thread network static routes on Ubiquiti routers
 type: application
-version: 0.1.44
-appVersion: "0.1.44"
+version: 0.1.45
+appVersion: "0.1.45"
 home: https://github.com/rafaelgaspar/unifi-thread-route-updater
 sources:
   - https://github.com/rafaelgaspar/unifi-thread-route-updater

--- a/chart/unifi-thread-route-updater/templates/deployment.yaml
+++ b/chart/unifi-thread-route-updater/templates/deployment.yaml
@@ -11,6 +11,13 @@ spec:
   selector:
     matchLabels:
       {{- include "unifi-thread-route-updater.selectorLabels" . | nindent 6 }}
+  {{- if .Values.networkAttachmentDefinition.enabled }}
+  strategy:
+    type: Recreate
+  {{- else if .Values.strategy }}
+  strategy:
+    {{- toYaml .Values.strategy | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/chart/unifi-thread-route-updater/templates/deployment.yaml
+++ b/chart/unifi-thread-route-updater/templates/deployment.yaml
@@ -11,13 +11,8 @@ spec:
   selector:
     matchLabels:
       {{- include "unifi-thread-route-updater.selectorLabels" . | nindent 6 }}
-  {{- if .Values.networkAttachmentDefinition.enabled }}
-  strategy:
-    type: Recreate
-  {{- else if .Values.strategy }}
   strategy:
     {{- toYaml .Values.strategy | nindent 4 }}
-  {{- end }}
   template:
     metadata:
       annotations:

--- a/chart/unifi-thread-route-updater/values.yaml
+++ b/chart/unifi-thread-route-updater/values.yaml
@@ -3,6 +3,10 @@
 
 replicaCount: 1
 
+# Deployment strategy when networkAttachmentDefinition is disabled (ignored when NAD is enabled — always Recreate).
+strategy:
+  type: RollingUpdate
+
 image:
   repository: ghcr.io/rafaelgaspar/unifi-thread-route-updater
   pullPolicy: IfNotPresent

--- a/chart/unifi-thread-route-updater/values.yaml
+++ b/chart/unifi-thread-route-updater/values.yaml
@@ -3,7 +3,7 @@
 
 replicaCount: 1
 
-# Deployment strategy when networkAttachmentDefinition is disabled (ignored when NAD is enabled — always Recreate).
+# Deployment strategy (use Recreate for pinned macvlan MACs).
 strategy:
   type: RollingUpdate
 


### PR DESCRIPTION
## Summary
- Expose `strategy` via chart values (default `RollingUpdate`)
- No automatic override when Multus NAD is enabled — callers set `strategy.type: Recreate` when needed (e.g. pinned macvlan MAC)
- Bump chart to `0.1.45`

## Test plan
- [x] `helm lint` with `strategy.type=Recreate`
- [ ] Tag `v0.1.45` after merge
- [ ] Merge k3s-home PR #561 (sets `strategy.type: Recreate` in HelmRelease values)