### PR TITLE
feat(ci): attach Helm chart to app image via OCI referrer

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -128,7 +128,7 @@ jobs:
       with:
         sarif_file: 'trivy-results.sarif'
 
-  push-image:
+  push-image-and-chart:
     needs: [build-image, lint-chart, security-scan]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
@@ -137,6 +137,9 @@ jobs:
       packages: write
 
     steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
     - name: Log in to Container Registry
       uses: docker/login-action@06fb636fac595d6fb4b28a5dfcb21a6f5091859c # v4
       with:
@@ -164,18 +167,6 @@ jobs:
           docker buildx imagetools create --tag "$TAG" "$SOURCE"
         done
 
-  publish-helmchart:
-    needs: [build-image, lint-chart, security-scan]
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
     - name: Set up Helm
       uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
       with:
@@ -183,13 +174,6 @@ jobs:
 
     - name: Set up ORAS
       uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
-
-    - name: Log in to Container Registry
-      uses: docker/login-action@06fb636fac595d6fb4b28a5dfcb21a6f5091859c # v4
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Package Helm chart
       run: helm package chart/unifi-thread-route-updater --destination ./packages

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -68,6 +68,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
 
     steps:
     - name: Checkout code
@@ -85,6 +87,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push image (SHA tag)
+      id: build
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
       with:
         context: .
@@ -178,6 +181,9 @@ jobs:
       with:
         version: '4.2.3'
 
+    - name: Set up ORAS
+      uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
+
     - name: Log in to Container Registry
       uses: docker/login-action@06fb636fac595d6fb4b28a5dfcb21a6f5091859c # v4
       with:
@@ -185,10 +191,16 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Package and push Helm chart
+    - name: Package Helm chart
+      run: helm package chart/unifi-thread-route-updater --destination ./packages
+
+    - name: Attach Helm chart to image as OCI layer
       run: |
-        helm package chart/unifi-thread-route-updater --destination ./packages
-        helm push ./packages/unifi-thread-route-updater-*.tgz oci://${{ env.REGISTRY }}/${{ github.repository }}/chart
+        CHART_FILE=$(ls ./packages/unifi-thread-route-updater-*.tgz)
+        oras attach \
+          --artifact-type application/vnd.cncf.helm.chart.content.v1.tar+gzip \
+          "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build-image.outputs.digest }}" \
+          "${CHART_FILE}:application/vnd.cncf.helm.chart.content.v1.tar+gzip"
 
   release-go-binaries:
     needs: [build-image, lint-chart, security-scan]

--- a/chart/unifi-thread-route-updater/Chart.yaml
+++ b/chart/unifi-thread-route-updater/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: unifi-thread-route-updater
 description: A Helm chart for Thread Route Updater - automatically manages Thread network static routes on Ubiquiti routers
 type: application
-version: 0.1.45
-appVersion: "0.1.45"
+version: 0.1.46
+appVersion: "0.1.46"
 home: https://github.com/rafaelgaspar/unifi-thread-route-updater
 sources:
   - https://github.com/rafaelgaspar/unifi-thread-route-updater


### PR DESCRIPTION
## Summary
- CI currently publishes the Helm chart as its own OCI artifact under `ghcr.io/<repo>/chart`, a separate repository from the app image.
- This attaches the packaged chart to the same app image instead, using `oras attach` to link it via the OCI 1.1 subject/referrers mechanism, with layer `mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip`.
- `docker manifest`/`buildx imagetools` can't do this — they only combine/re-tag existing manifests and have no concept of attaching an extra artifact with a custom media type, so `oras` is used instead (same approach Docker's own SBOM/provenance attestations use under the hood).
- `build-image` now exposes its pushed digest as a job output so `publish-helmchart` can attach to the exact image digest (shared across all release tags, since they're re-tagged copies of the same manifest).

## Test plan
- [ ] `ct lint --all --config ct.yaml` still passes (unchanged chart, existing `lint-chart` job)
- [ ] On a tagged release, verify `oras attach` succeeds and `oras discover ghcr.io/<repo>:<tag>` (or the GHCR UI) shows the chart artifact linked to the image
- [ ] Confirm the previous `ghcr.io/<repo>/chart` package is no longer being written to, and decide whether to delete old published versions there

🤖 Generated with [Claude Code](https://claude.com/claude-code)