### PR TITLE
ci: add explicit permissions to test and lint-chart jobs

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -11,11 +11,12 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -49,8 +50,6 @@ jobs:
 
   lint-chart:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,6 +14,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -47,6 +49,8 @@ jobs:
 
   lint-chart:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
## Summary
- Adds `permissions: contents: read` to the `test` and `lint-chart` jobs in `build-and-release.yml`, addressing CodeQL code-scanning alerts [#11](https://github.com/rafaelgaspar/unifi-thread-route-updater/security/code-scanning/11) and [#12](https://github.com/rafaelgaspar/unifi-thread-route-updater/security/code-scanning/12) (missing workflow permissions). Every other job in the workflow already scopes its token; these two only need read access to check out code.

The remaining open code-scanning alerts (#1–#7, #10) are Trivy findings against `golang.org/x/net` / `golang.org/x/sys` versions that are already below what `go.mod` currently requires (the dependency bump landed in defdf7d, the same day the alerts opened). They're stale scan results and will auto-resolve once `security-scan` runs again on `main` post-merge — no dependency change needed here.

## Test plan
- [x] `go build .`
- [x] `go test ./...`
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] CI green on this PR (`test`, `lint-chart` jobs)