### PR TITLE
ci: workflow-level permissions default + scoped Trivy scan

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -11,11 +11,12 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -49,8 +50,6 @@ jobs:
 
   lint-chart:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,6 +14,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -47,6 +49,8 @@ jobs:
 
   lint-chart:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -117,12 +117,21 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    # scanners: vuln only — secret scanning is already covered by gitleaks.yaml,
+    # and misconfig scanning here would flag this repo's own workflow files
+    # (unrelated to what's actually inside the image). ignore-unfixed +
+    # severity drop the large volume of low/unfixed base-image CVEs that
+    # Renovate/apk upgrade can't do anything about, so what lands in the
+    # Security tab is limited to real, actionable HIGH/CRITICAL findings.
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
         format: 'sarif'
         output: 'trivy-results.sarif'
+        scanners: 'vuln'
+        severity: 'CRITICAL,HIGH'
+        ignore-unfixed: 'true'
         exit-code: '0'
 
     - name: Upload Trivy scan results to GitHub Security tab


### PR DESCRIPTION
## Summary
- Moves the default `permissions: contents: read` from per-job (`test`, `lint-chart`) to the workflow level, so it's declared once instead of repeated; jobs that need more (`build-image`, `security-scan`, `push-image-and-chart`, `release-go-binaries`) still override it with their own block.
- Scopes the Trivy scan in `security-scan` to match `longhorn-mcp`'s `ci.yaml`: `scanners: vuln` only (secret scanning is already covered by `gitleaks.yaml`), `severity: CRITICAL,HIGH`, and `ignore-unfixed: true`. This cuts the low-severity/unfixed base-image CVE noise so the Security tab only surfaces actionable findings.

## Test plan
- [x] YAML parses
- [ ] CI green on this PR