### PR TITLE
feat(chart): add hostAliases support

### DIFF
--- a/chart/unifi-thread-route-updater/templates/deployment.yaml
+++ b/chart/unifi-thread-route-updater/templates/deployment.yaml
@@ -95,6 +95,10 @@ spec:
             failureThreshold: 3
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/chart/unifi-thread-route-updater/values.yaml
+++ b/chart/unifi-thread-route-updater/values.yaml
@@ -93,6 +93,11 @@ tolerations: []
 
 affinity: {}
 
+hostAliases: []
+# - ip: "192.168.1.1"
+#   hostnames:
+#     - unifi.local.example.com
+
 # Configuration for the application
 config:
   # Logging level (DEBUG, INFO, WARN, ERROR)


### PR DESCRIPTION
## Summary
Some routers (e.g. Ubiquiti's UDM/USG family) advertise their own hostname via mDNS/local DNS with one A/AAAA record per VLAN interface, rather than a single canonical address. A plain DNS lookup for `UBIQUITY_ROUTER_HOSTNAME` can then return several unreachable candidates alongside the one actually reachable from a given pod — the Go HTTP client tries each in turn, wasting time on dead ends before reaching the working one (and can time out entirely under a tight deadline).

## Change
Adds a standard `hostAliases` value, rendered into the Deployment's pod spec exactly like the existing `nodeSelector`/`tolerations`/`affinity` passthroughs — lets a deployment pin the router hostname to the correct address via `/etc/hosts`, bypassing the ambiguous DNS answer entirely.

## Verification
- `helm lint chart/unifi-thread-route-updater` — clean.
- `helm template` with a sample `hostAliases` value — renders correctly into the pod spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)